### PR TITLE
More static binary - BUILD_SHARED_LIBS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
+
+set(BUILD_SHARED_LIBS OFF) # static linking of included libraries (cpr & libcurl)
+
 project(stockprice)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
BUILD_SHARED_LIBS=OFF, means that any libraries built as part of your project will be built as static libraries (Libcurl and CPR)

Note that this doesnt mean the final binary will be completely static, as system library dependencies are still dynamically linked. If the libraries that are dynamically linked are not available on the computer, the binary will not be runnable.